### PR TITLE
Removes apostrophe from curl data parameter.

### DIFF
--- a/content/cookbook/index.md
+++ b/content/cookbook/index.md
@@ -127,7 +127,7 @@ echo json_encode(array('success' => true, 'message' => 'You accessed my APIs!'))
 Now run the following from the command line:
 
 ```text
-curl http://localhost/resource.php -d 'access_token=YOUR_TOKEN'
+curl http://localhost/resource.php -d access_token=YOUR_TOKEN
 ```
 
 > Note: Use the value returned in "access_token" from the previous step in place of YOUR_TOKEN

--- a/content/cookbook/index.md
+++ b/content/cookbook/index.md
@@ -93,7 +93,7 @@ INSERT INTO oauth_clients (client_id, client_secret, redirect_uri) VALUES ("test
 Now run the following from the command line:
 
 ```text
-curl -u testclient:testpass http://localhost/token.php -d 'grant_type=client_credentials'
+curl -u testclient:testpass http://localhost/token.php -d grant_type=client_credentials
 ```
 
 > Note: http://localhost/token.php assumes you have the file `token.php` on your local machine, and you have


### PR DESCRIPTION
Removes the apostrophes surrounding the curl data option grant_type=client_credentials as it was not working on Windows 7 command line.
